### PR TITLE
Respect the `storageOffset` attribute in the `name` table

### DIFF
--- a/src/name.rs
+++ b/src/name.rs
@@ -158,3 +158,29 @@ impl NameRecord {
             || (self.platform_id == 3 && [0, 1, 10].contains(&self.encoding_id))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_respects_storage_offset() {
+        let mut data = Vec::new();
+        data.extend(0u16.to_be_bytes()); // version
+        data.extend(1u16.to_be_bytes()); // count
+        data.extend(24u16.to_be_bytes()); // storageOffset
+        data.extend(3u16.to_be_bytes()); // nameRecord[0].platformID
+        data.extend(1u16.to_be_bytes()); // nameRecord[0].encodingID
+        data.extend(0x0409u16.to_be_bytes()); // nameRecord[0].languageID
+        data.extend(0u16.to_be_bytes()); // nameRecord[0].nameID
+        data.extend(4u16.to_be_bytes()); // nameRecord[0].length
+        data.extend(0u16.to_be_bytes()); // nameRecord[0].stringOffset
+        data.extend(*b"BAD!"); // padding before storageOffset
+        data.extend([0, b'O', 0, b'K']); // storage
+
+        let table = Table::parse(&data).unwrap();
+        let subset = subset_table(&table).unwrap();
+
+        assert_eq!(subset.storage.as_ref(), &[0, b'O', 0, b'K']);
+    }
+}

--- a/src/name.rs
+++ b/src/name.rs
@@ -106,7 +106,7 @@ impl<'a> Table<'a> {
         }
 
         let count = r.read::<u16>()?;
-        r.read::<u16>()?; // storage offset
+        let storage_offset = r.read::<u16>()?;
 
         let mut names = Vec::with_capacity(count as usize);
 
@@ -114,7 +114,7 @@ impl<'a> Table<'a> {
             names.push(r.read::<NameRecord>()?);
         }
 
-        let storage = Cow::Borrowed(r.tail()?);
+        let storage = Cow::Borrowed(data.get(storage_offset as usize..)?);
 
         Some(Self { names, storage })
     }
@@ -168,7 +168,7 @@ mod tests {
         let mut data = Vec::new();
         data.extend(0u16.to_be_bytes()); // version
         data.extend(1u16.to_be_bytes()); // count
-        data.extend(24u16.to_be_bytes()); // storageOffset
+        data.extend(22u16.to_be_bytes()); // storageOffset
         data.extend(3u16.to_be_bytes()); // nameRecord[0].platformID
         data.extend(1u16.to_be_bytes()); // nameRecord[0].encodingID
         data.extend(0x0409u16.to_be_bytes()); // nameRecord[0].languageID


### PR DESCRIPTION
We've basically assumed that this is always 0. See https://learn.microsoft.com/en-us/typography/opentype/spec/name#naming-table-version-0